### PR TITLE
Remove note about caching previews from production

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Persist [Hugo](https://gohugo.io/) resources folder between Netlify builds for h
 
 This plugin caches the `resources` folder after build. If you are processing many images, this would improve build duration significantly.
 
-Note: Restoring cache only comes from the production branch. So once cache is saved on the production branch, the next preview build would use the cache. For example, when pushing to the same preview build, the latest preview build will not get the cache from the previous preview build, but will get it from master.
-
 ## Usage
 
 You can install this plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/netlify-plugin-hugo-cache-resources/install) or from the [Plugins directory](https://app.netlify.com/plugins).


### PR DESCRIPTION
I came across this note while we're preparing to feature the Hugo Cache Resources plugin on our blog. Since it was written, Netlify now maintains [separate build caches for deploy previews](https://answers.netlify.com/t/build-cache-is-now-updated-in-deploy-preview-builds/26344).

I removed the note because I think the new behavior works as people would expect: a new preview build doesn't have a preview cache yet (so uses the production cache to at least get some caching benefit), but subsequent preview builds use the cache from the previous preview build.

I'm happy to offer an edit if you think it makes more sense to have an explicit note about it.